### PR TITLE
Add Sentinel workflow skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # AutoPilotOps
+
+This repository contains a minimal reference implementation of the
+**Sentinel** remediation workflow.  A CloudWatch alarm triggers an
+EventBridge rule which starts a Step Functions state machine. The state
+machine orchestrates a series of Lambda-based agents:
+
+1. **DiagnoserAgent** – inspects metrics and logs to determine the cause
+   of the alarm.
+2. **PlannerAgent** – maps the diagnosis to one or more remediation
+   actions.
+3. **ExecutorAgent** – invokes AWS APIs to perform the remediation.
+4. **TesterAgent** – verifies that the remediation succeeded.
+5. **ReflectorAgent** – performs a brief post-mortem and records the
+   outcome.
+
+The Step Functions definition is stored in
+`state_machine/sentinel_state_machine.asl.json` and the AWS SAM template
+`template.yaml` links the pieces together. The Lambda handlers are found
+under the `agents/` directory.
+
+These components are only stubs intended to illustrate the flow between
+services. They can be deployed with the AWS SAM CLI:
+
+```bash
+sam build && sam deploy --guided
+```

--- a/agents/diagnoser.py
+++ b/agents/diagnoser.py
@@ -1,0 +1,15 @@
+"""DiagnoserAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+
+
+def handler(event: dict, context=None) -> dict:
+    """Diagnose the cause of the alarm.
+
+    This placeholder implementation simply returns a fixed diagnosis.
+    """
+    diagnosis = {"reason": "High CPU utilization detected"}
+    print(json.dumps(diagnosis))
+    return diagnosis

--- a/agents/executor.py
+++ b/agents/executor.py
@@ -1,0 +1,16 @@
+"""ExecutorAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+
+
+def handler(event: dict, context=None) -> dict:
+    """Execute the remediation actions."""
+    plan = event.get("plan", [])
+    results = []
+    for item in plan:
+        results.append({"action": item.get("action"), "status": "success"})
+    result = {"results": results}
+    print(json.dumps(result))
+    return result

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -1,0 +1,16 @@
+"""PlannerAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+
+
+def handler(event: dict, context=None) -> dict:
+    """Generate a remediation plan based on the diagnosis."""
+    diagnosis = event.get("reason", "")
+    plan = []
+    if "High CPU" in diagnosis:
+        plan.append({"action": "RestartInstance"})
+    result = {"plan": plan}
+    print(json.dumps(result))
+    return result

--- a/agents/reflector.py
+++ b/agents/reflector.py
@@ -1,0 +1,14 @@
+"""ReflectorAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+
+
+def handler(event: dict, context=None) -> dict:
+    """Summarize the outcome of the remediation."""
+    test_passed = event.get("test_passed", False)
+    summary = "Remediation succeeded" if test_passed else "Remediation failed"
+    result = {"summary": summary}
+    print(json.dumps(result))
+    return result

--- a/agents/tester.py
+++ b/agents/tester.py
@@ -1,0 +1,14 @@
+"""TesterAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+
+
+def handler(event: dict, context=None) -> dict:
+    """Verify that the remediation actions had the desired effect."""
+    results = event.get("results", [])
+    success = all(item.get("status") == "success" for item in results)
+    result = {"test_passed": success}
+    print(json.dumps(result))
+    return result

--- a/run_local.py
+++ b/run_local.py
@@ -1,0 +1,13 @@
+from agents.diagnoser import handler as diagnoser
+from agents.planner import handler as planner
+from agents.executor import handler as executor
+from agents.tester import handler as tester
+from agents.reflector import handler as reflector
+
+state = {}
+state.update(diagnoser(state))
+state.update(planner(state))
+state.update(executor(state))
+state.update(tester(state))
+state.update(reflector(state))
+print(state)

--- a/state_machine/sentinel_state_machine.asl.json
+++ b/state_machine/sentinel_state_machine.asl.json
@@ -1,0 +1,31 @@
+{
+  "Comment": "Sentinel workflow orchestrating all agents",
+  "StartAt": "Diagnoser",
+  "States": {
+    "Diagnoser": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:DiagnoserFunction",
+      "Next": "Planner"
+    },
+    "Planner": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:PlannerFunction",
+      "Next": "Executor"
+    },
+    "Executor": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:ExecutorFunction",
+      "Next": "Tester"
+    },
+    "Tester": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:TesterFunction",
+      "Next": "Reflector"
+    },
+    "Reflector": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:ReflectorFunction",
+      "End": true
+    }
+  }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,105 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: AutoPilotOps Sentinel stack.
+
+Resources:
+  DiagnoserFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/diagnoser.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  PlannerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/planner.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  ExecutorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/executor.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  TesterFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/tester.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  ReflectorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/reflector.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  SentinelStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: state_machine/sentinel_state_machine.asl.json
+      DefinitionSubstitutions:
+        REGION: !Ref "AWS::Region"
+        ACCOUNT_ID: !Ref "AWS::AccountId"
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: "*"
+
+  HighCPUAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: High CPU utilization alarm
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 80
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: InstanceId
+          Value: i-1234567890abcdef0
+
+  AlarmRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.cloudwatch
+        detail-type:
+          - CloudWatch Alarm State Change
+        detail:
+          alarmName:
+            - !Ref HighCPUAlarm
+      Targets:
+        - Id: StartSentinel
+          Arn: !Ref SentinelStateMachine
+          RoleArn: !GetAtt AlarmInvokeRole.Arn
+
+  AlarmInvokeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: StartStateMachine
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: states:StartExecution
+                Resource: !Ref SentinelStateMachine
+
+Outputs:
+  StateMachineArn:
+    Description: Sentinel state machine ARN
+    Value: !Ref SentinelStateMachine


### PR DESCRIPTION
## Summary
- flesh out README with overview of Sentinel workflow
- add stub Lambda handlers for Diagnoser, Planner, Executor, Tester and Reflector
- provide Step Functions definition for the Sentinel state machine
- supply a SAM template that wires alarms and the workflow together
- example script `run_local.py` showing local invocation order

## Testing
- `python -m py_compile agents/*.py`
- `python run_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684ba50cf288832e8bbb8cf302f3fc14