### PR TITLE
Add Sentinel agent and improve workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # AutoPilotOps
+
+This repository contains a minimal reference implementation of the
+**Sentinel** remediation workflow.  A CloudWatch alarm triggers an
+EventBridge rule which invokes a small **SentinelAgent** Lambda.  This
+function parses the alarm and then starts a Step Functions state machine.
+The state
+machine orchestrates a series of Lambda-based agents:
+
+1. **DiagnoserAgent** – inspects metrics and logs to determine the cause
+   of the alarm.
+2. **PlannerAgent** – maps the diagnosis to one or more remediation
+   actions.
+3. **ExecutorAgent** – invokes AWS APIs to perform the remediation.
+4. **TesterAgent** – verifies that the remediation succeeded.
+5. **ReflectorAgent** – performs a brief post-mortem and records the
+   outcome.
+
+The DiagnoserAgent loads a prompt from `prompts/diagnosis_prompt.txt` and
+simulates an LLM call to produce a structured diagnosis.  PlannerAgent
+converts the suggested `next_steps` into a plan of actions which the
+ExecutorAgent carries out. TesterAgent confirms that something was done and
+ReflectorAgent summarises the result.
+
+The Step Functions definition is stored in
+`state_machine/sentinel_state_machine.asl.json` and the AWS SAM template
+`template.yaml` links the pieces together. The Lambda handlers are found
+under the `agents/` directory and a small script `run_local.py` shows the
+execution flow locally.
+
+These components are only stubs intended to illustrate the flow between
+services. They can be deployed with the AWS SAM CLI:
+
+```bash
+sam build && sam deploy --guided
+```

--- a/agents/diagnoser.py
+++ b/agents/diagnoser.py
@@ -1,0 +1,38 @@
+"""DiagnoserAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Any, Dict
+
+
+# Fake metrics fetcher for local demo
+_DEF_METRICS = [{"Timestamp": "2025-06-13T00:00:00Z", "Average": 92.5}]
+
+
+def _load_prompt() -> str:
+    prompt_path = pathlib.Path("prompts/diagnosis_prompt.txt")
+    return prompt_path.read_text()
+
+
+def _call_llm(prompt: str) -> Dict[str, Any]:
+    """Simulate an LLM call with a deterministic response."""
+    # In a real implementation this would invoke an API like OpenAI or Groq.
+    return {
+        "cause": "Application load test running",
+        "confidence": 0.85,
+        "next_steps": "restart_instance"
+    }
+
+
+def handler(event: Dict[str, Any], context: Any = None) -> Dict[str, Any]:
+    """Diagnose the cause of the alarm."""
+    instance_id = event.get("instance_id", "unknown")
+    metrics = _DEF_METRICS
+    prompt = _load_prompt()
+    llm_input = f"{prompt}\n{json.dumps(metrics)}"
+    diagnosis = _call_llm(llm_input)
+    diagnosis["instance_id"] = instance_id
+    print(json.dumps(diagnosis))
+    return diagnosis

--- a/agents/executor.py
+++ b/agents/executor.py
@@ -1,0 +1,22 @@
+"""ExecutorAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+
+def _execute(action: str, instance_id: str) -> Dict[str, str]:
+    """Simulate executing an action."""
+    # Real implementation would call AWS APIs here
+    return {"action": action, "status": f"executed on {instance_id}"}
+
+
+def handler(event: Dict[str, Any], context: Any = None) -> Dict[str, Any]:
+    """Execute the remediation actions."""
+    plan: List[Dict[str, Any]] = event.get("plan", [])
+    instance_id = event.get("instance_id", "unknown")
+    results = [_execute(item.get("action", ""), instance_id) for item in plan]
+    result = {"results": results, "instance_id": instance_id}
+    print(json.dumps(result))
+    return result

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -1,0 +1,25 @@
+"""PlannerAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+
+def _parse_steps(steps: str) -> List[Dict[str, Any]]:
+    plan = []
+    for step in steps.split(','):
+        action = step.strip()
+        if not action:
+            continue
+        plan.append({"action": action})
+    return plan
+
+
+def handler(event: Dict[str, Any], context: Any = None) -> Dict[str, Any]:
+    """Generate a remediation plan based on the diagnosis."""
+    steps = event.get("next_steps", "")
+    plan = _parse_steps(steps)
+    result = {"plan": plan, "instance_id": event.get("instance_id")}
+    print(json.dumps(result))
+    return result

--- a/agents/reflector.py
+++ b/agents/reflector.py
@@ -1,0 +1,21 @@
+"""ReflectorAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+def _post_mortem(passed: bool) -> str:
+    if passed:
+        return "Remediation succeeded. Consider monitoring thresholds."
+    return "Remediation failed. Additional investigation required."
+
+
+def handler(event: Dict[str, Any], context: Any = None) -> Dict[str, Any]:
+    """Summarize the outcome of the remediation."""
+    test_passed = event.get("test_passed", False)
+    summary = _post_mortem(test_passed)
+    result = {"summary": summary, "instance_id": event.get("instance_id")}
+    print(json.dumps(result))
+    return result

--- a/agents/sentinel.py
+++ b/agents/sentinel.py
@@ -1,0 +1,29 @@
+"""SentinelAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+def handler(event: Dict[str, Any], context: Any = None) -> Dict[str, Any]:
+    """Parse an alarm event and start the Sentinel workflow.
+
+    In a real deployment this would call Step Functions. Here we just return
+    the extracted instance ID so the local demo can proceed.
+    """
+    detail = event.get("detail", {})
+    metrics = (
+        detail.get("configuration", {})
+        .get("metrics", [{}])
+    )
+    instance_id = (
+        metrics[0]
+        .get("metricStat", {})
+        .get("metric", {})
+        .get("dimensions", {})
+        .get("InstanceId", "unknown")
+    )
+    print(json.dumps({"starting_execution_for": instance_id}))
+    # Here we would call Step Functions' StartExecution API
+    return {"instance_id": instance_id}

--- a/agents/tester.py
+++ b/agents/tester.py
@@ -1,0 +1,16 @@
+"""TesterAgent lambda function."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+
+def handler(event: Dict[str, Any], context: Any = None) -> Dict[str, Any]:
+    """Verify that the remediation actions had the desired effect."""
+    results: List[Dict[str, str]] = event.get("results", [])
+    # Stub check: if we executed anything, consider it successful
+    success = bool(results)
+    result = {"test_passed": success, "instance_id": event.get("instance_id")}
+    print(json.dumps(result))
+    return result

--- a/prompts/diagnosis_prompt.txt
+++ b/prompts/diagnosis_prompt.txt
@@ -1,0 +1,1 @@
+Please analyze the following metrics JSON and identify the most likely root cause of the alarm. Provide a JSON response with `cause`, `confidence`, and `next_steps`.

--- a/run_local.py
+++ b/run_local.py
@@ -1,0 +1,32 @@
+from agents.sentinel import handler as sentinel
+from agents.diagnoser import handler as diagnoser
+from agents.planner import handler as planner
+from agents.executor import handler as executor
+from agents.tester import handler as tester
+from agents.reflector import handler as reflector
+
+# Sample alarm event
+event = {
+    "detail": {
+        "alarmName": "HighCPUAlarm",
+        "configuration": {
+            "metrics": [
+                {
+                    "metricStat": {
+                        "metric": {
+                            "dimensions": {"InstanceId": "i-1234567890abcdef0"}
+                        }
+                    }
+                }
+            ]
+        },
+    }
+}
+
+state = sentinel(event)
+state.update(diagnoser(state))
+state.update(planner(state))
+state.update(executor(state))
+state.update(tester(state))
+state.update(reflector(state))
+print(state)

--- a/state_machine/sentinel_state_machine.asl.json
+++ b/state_machine/sentinel_state_machine.asl.json
@@ -1,0 +1,31 @@
+{
+  "Comment": "Sentinel workflow orchestrating all agents",
+  "StartAt": "Diagnoser",
+  "States": {
+    "Diagnoser": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:DiagnoserFunction",
+      "Next": "Planner"
+    },
+    "Planner": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:PlannerFunction",
+      "Next": "Executor"
+    },
+    "Executor": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:ExecutorFunction",
+      "Next": "Tester"
+    },
+    "Tester": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:TesterFunction",
+      "Next": "Reflector"
+    },
+    "Reflector": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:ReflectorFunction",
+      "End": true
+    }
+  }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,98 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: AutoPilotOps Sentinel stack.
+
+Resources:
+  DiagnoserFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/diagnoser.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  PlannerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/planner.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  ExecutorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/executor.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  TesterFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/tester.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  ReflectorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/reflector.handler
+      Runtime: python3.9
+      CodeUri: .
+
+  SentinelFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: agents/sentinel.handler
+      Runtime: python3.9
+      CodeUri: .
+      Policies:
+        - Statement:
+            Effect: Allow
+            Action: states:StartExecution
+            Resource: !Ref SentinelStateMachine
+
+  SentinelStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: state_machine/sentinel_state_machine.asl.json
+      DefinitionSubstitutions:
+        REGION: !Ref "AWS::Region"
+        ACCOUNT_ID: !Ref "AWS::AccountId"
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: "*"
+
+  HighCPUAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: High CPU utilization alarm
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 80
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: InstanceId
+          Value: i-1234567890abcdef0
+
+  AlarmRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.cloudwatch
+        detail-type:
+          - CloudWatch Alarm State Change
+        detail:
+          alarmName:
+            - !Ref HighCPUAlarm
+      Targets:
+        - Id: InvokeSentinel
+          Arn: !GetAtt SentinelFunction.Arn
+
+
+Outputs:
+  StateMachineArn:
+    Description: Sentinel state machine ARN
+    Value: !Ref SentinelStateMachine


### PR DESCRIPTION
## Summary
- wire EventBridge rule to new `SentinelFunction`
- stub Sentinel agent parses alarm and passes instance ID
- expand agent logic with prompts and simple action handling
- include diagnosis prompt example and local demo update

## Testing
- `python -m py_compile agents/*.py`
- `python run_local.py`


------
https://chatgpt.com/codex/tasks/task_e_684ba50cf288832e8bbb8cf302f3fc14